### PR TITLE
Add feature extraction module and setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,29 @@
 # Codex_Puzzle
 
-This repository contains notebooks experimenting with computer vision techniques for jigsaw puzzle pieces. The goal is to explore ways to segment images of puzzles and attempt reassembly programmatically.
+This repository contains notebooks and Python modules experimenting with computer vision techniques for jigsaw puzzle pieces. The goal is to explore ways to segment images of puzzles and attempt reassembly programmatically.
 
 ## Contents
 
 - **Kaggle_Jigsaw.ipynb** – Demonstrates thresholding and contour detection with OpenCV. The notebook walks through creating bounding boxes around individual pieces and saving them as separate images.
-- **Masking_puzzle.ipynb** – A larger workflow that connects to Google Drive, removes backgrounds with GrabCut segmentation, performs feature extraction and corner detection, and includes sample code to display selected puzzle pieces.
+- **Masking_puzzle.ipynb** – A larger workflow that removes backgrounds with GrabCut segmentation, performs feature extraction and corner detection, and includes sample code to display selected puzzle pieces.
+- **puzzle/** – Python package containing reusable functions for segmentation, feature extraction and puzzle assembly.
 
-Both notebooks are rough experiments used to test Codex for a puzzle project. They are not yet cleaned up for production use, but serve as a starting point for future development.
+## Setup
+
+The project requires Python 3.8+ with the packages listed in `requirements.txt`. To install them run:
+
+```bash
+./setup.sh
+```
+
+## Tests
+
+Simple unit tests are provided for the main utilities. Execute them with:
+
+```bash
+pytest
+```
+
+These tests do not require the original puzzle images and serve only as sanity checks for the library functions.
+
+

--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -1,0 +1,19 @@
+from .segmentation import (
+    remove_background,
+    detect_piece_corners,
+    select_four_corners,
+    is_edge_straight,
+    classify_piece_type,
+)
+from .features import extract_edge_descriptors
+from .assembly import render_puzzle
+
+__all__ = [
+    "remove_background",
+    "detect_piece_corners",
+    "select_four_corners",
+    "is_edge_straight",
+    "classify_piece_type",
+    "extract_edge_descriptors",
+    "render_puzzle",
+]

--- a/puzzle/assembly.py
+++ b/puzzle/assembly.py
@@ -1,0 +1,32 @@
+import cv2
+import numpy as np
+
+
+def render_puzzle(placements, piece_images, canvas_size):
+    """Render assembled puzzle given piece placements.
+
+    Parameters
+    ----------
+    placements : list of tuples
+        Sequence of (piece_id, x, y, rotation_deg).
+    piece_images : dict
+        Mapping piece_id -> BGR image for that piece.
+    canvas_size : tuple
+        (height, width) of the resulting canvas.
+    """
+    canvas = np.zeros((canvas_size[0], canvas_size[1], 3), dtype=np.uint8)
+    for piece_id, x, y, rot in placements:
+        img = piece_images[piece_id]
+        if rot % 360 != 0:
+            center = (img.shape[1] // 2, img.shape[0] // 2)
+            M = cv2.getRotationMatrix2D(center, rot, 1.0)
+            img = cv2.warpAffine(img, M, (img.shape[1], img.shape[0]))
+        h, w = img.shape[:2]
+        x_end = min(canvas.shape[1], x + w)
+        y_end = min(canvas.shape[0], y + h)
+        canvas[y:y_end, x:x_end] = np.where(
+            img[0 : y_end - y, 0 : x_end - x] == 0,
+            canvas[y:y_end, x:x_end],
+            img[0 : y_end - y, 0 : x_end - x],
+        )
+    return canvas

--- a/puzzle/features.py
+++ b/puzzle/features.py
@@ -1,0 +1,62 @@
+import cv2
+import numpy as np
+
+
+def _edge_strip_mask(mask, pt1, pt2, width):
+    """Create a binary mask for a strip along an edge defined by two points."""
+    strip = np.zeros_like(mask, dtype=np.uint8)
+    cv2.line(strip, tuple(pt1), tuple(pt2), color=1, thickness=width)
+    return (strip & mask).astype(np.uint8)
+
+
+def _color_histogram(img, mask, bins=8):
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+    hist = cv2.calcHist([hsv], [0, 1, 2], mask, [bins, bins, bins], [0, 180, 0, 256, 0, 256])
+    cv2.normalize(hist, hist)
+    return hist.flatten()
+
+
+def _sift_descriptors(img, mask):
+    try:
+        sift = cv2.SIFT_create()
+    except AttributeError:
+        return None
+    keypoints, desc = sift.detectAndCompute(img, mask)
+    if desc is None:
+        return None
+    return desc.mean(axis=0)
+
+
+def extract_edge_descriptors(image, mask, corners, edge_width: int = 15, hist_bins: int = 8):
+    """Compute descriptors for each edge of a piece.
+
+    Parameters
+    ----------
+    image : ndarray
+        Original BGR image of the puzzle piece.
+    mask : ndarray
+        Binary mask of the piece (1=piece, 0=background).
+    corners : ndarray
+        4x2 array of corner coordinates in order.
+    edge_width : int
+        Thickness of the strip sampled along each edge.
+    hist_bins : int
+        Number of bins per channel for the color histogram.
+
+    Returns
+    -------
+    list[dict]
+        A list of dictionaries with keys 'hist' and 'sift' for each edge.
+    """
+    descriptors = []
+    for i in range(4):
+        pt1 = corners[i]
+        pt2 = corners[(i + 1) % 4]
+        strip_mask = _edge_strip_mask(mask, pt1, pt2, edge_width)
+        if np.count_nonzero(strip_mask) == 0:
+            descriptors.append({'hist': None, 'sift': None})
+            continue
+        hist = _color_histogram(image, strip_mask * 255, bins=hist_bins)
+        sift = _sift_descriptors(image, strip_mask * 255)
+        descriptors.append({'hist': hist, 'sift': sift})
+    return descriptors

--- a/puzzle/segmentation.py
+++ b/puzzle/segmentation.py
@@ -1,0 +1,65 @@
+import cv2
+import numpy as np
+from sklearn.cluster import KMeans
+
+
+def remove_background(piece_img, iter_count: int = 5, rect_margin: int = 1):
+    """Segment a puzzle piece from the background using GrabCut."""
+    mask = np.zeros(piece_img.shape[:2], dtype=np.uint8)
+    bgd_model = np.zeros((1, 65), dtype=np.float64)
+    fgd_model = np.zeros((1, 65), dtype=np.float64)
+    h, w = piece_img.shape[:2]
+    rect = (rect_margin, rect_margin, w - 2 * rect_margin, h - 2 * rect_margin)
+    cv2.grabCut(piece_img, mask, rect, bgd_model, fgd_model, iter_count, cv2.GC_INIT_WITH_RECT)
+    mask2 = np.where((mask == cv2.GC_FGD) | (mask == cv2.GC_PR_FGD), 1, 0).astype("uint8")
+    segmented = piece_img * mask2[:, :, np.newaxis]
+    return mask2, segmented
+
+
+def detect_piece_corners(mask, max_corners: int = 20, quality_level: float = 0.01, min_distance: int = 10):
+    """Detect corner points on the piece boundary using Shi-Tomasi."""
+    edges = cv2.Canny((mask * 255).astype(np.uint8), 50, 150)
+    corners = cv2.goodFeaturesToTrack(edges, maxCorners=max_corners, qualityLevel=quality_level, minDistance=min_distance)
+    if corners is None:
+        return np.empty((0, 2), dtype=np.int32)
+    return corners.astype(np.int32).reshape(-1, 2)
+
+
+def select_four_corners(corner_pts):
+    """Cluster many corner candidates into four representative corners."""
+    if len(corner_pts) < 4:
+        return corner_pts
+    kmeans = KMeans(n_clusters=4, random_state=42).fit(corner_pts)
+    return np.int32(kmeans.cluster_centers_)
+
+
+def is_edge_straight(mask, corner1, corner2, tolerance: float = 0.98, sample_points: int = 50):
+    """Check if the edge between two corners follows a straight boundary."""
+    x1, y1 = corner1
+    x2, y2 = corner2
+    h, w = mask.shape
+    x_coords = np.linspace(x1, x2, sample_points).astype(int)
+    y_coords = np.linspace(y1, y2, sample_points).astype(int)
+    valid = (x_coords >= 0) & (x_coords < w) & (y_coords >= 0) & (y_coords < h)
+    x_coords = x_coords[valid]
+    y_coords = y_coords[valid]
+    if len(x_coords) == 0:
+        return False
+    points_on_mask = mask[y_coords, x_coords]
+    percentage = np.sum(points_on_mask) / sample_points
+    return percentage >= tolerance
+
+
+def classify_piece_type(mask, corners):
+    """Heuristic classification into corner, edge or middle piece."""
+    straight_count = 0
+    for i in range(4):
+        a = tuple(corners[i])
+        b = tuple(corners[(i + 1) % 4])
+        if is_edge_straight(mask, a, b, tolerance=0.98):
+            straight_count += 1
+    if straight_count == 2:
+        return "corner"
+    elif straight_count == 1:
+        return "edge"
+    return "middle"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+opencv-python-headless
+numpy
+pandas
+scikit-learn
+matplotlib

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m pip install -r requirements.txt

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,13 @@
+import numpy as np
+import cv2
+from puzzle.features import extract_edge_descriptors
+
+
+def test_extract_edge_descriptors_simple_square():
+    img = np.full((10, 10, 3), 255, dtype=np.uint8)
+    mask = np.ones((10, 10), dtype=np.uint8)
+    corners = np.array([[0, 0], [9, 0], [9, 9], [0, 9]])
+    desc = extract_edge_descriptors(img, mask, corners, edge_width=2)
+    assert len(desc) == 4
+    for d in desc:
+        assert 'hist' in d and 'sift' in d

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,0 +1,8 @@
+import numpy as np
+from puzzle.segmentation import select_four_corners
+
+
+def test_select_four_corners_returns_four():
+    pts = np.array([[0, 0], [10, 0], [10, 10], [0, 10], [5, 5], [8, 8]])
+    corners = select_four_corners(pts)
+    assert corners.shape == (4, 2)


### PR DESCRIPTION
## Summary
- implement `extract_edge_descriptors` and helper utilities
- package segmentation and assembly functions in a `puzzle` module
- add simple unit tests
- provide `requirements.txt` and `setup.sh`
- update README with setup and testing instructions

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement opencv-python-headless)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b369b6c4883239b28603d3177809b