### PR TITLE
Add image drag-and-drop upload with selectable thumbnails

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,8 +1,90 @@
+import { useState, useEffect, useRef } from 'react';
+
 export default function Home() {
+  const [images, setImages] = useState([]);
+  const [selected, setSelected] = useState([]);
+  const inputRef = useRef(null);
+
+  const handleFiles = (files) => {
+    const newImages = Array.from(files).map((file) => ({
+      url: URL.createObjectURL(file),
+      name: file.name,
+    }));
+    setImages((prev) => [...prev, ...newImages]);
+  };
+
+  const handleChange = (e) => {
+    handleFiles(e.target.files);
+    e.target.value = null;
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const toggleSelect = (idx) => {
+    setSelected((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+    );
+  };
+
+  useEffect(() => {
+    return () => {
+      images.forEach((img) => URL.revokeObjectURL(img.url));
+    };
+  }, [images]);
+
   return (
     <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
       <h1>Codex Puzzle</h1>
       <p>Welcome to the puzzle application built with Next.js.</p>
+
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+        onClick={() => inputRef.current?.click()}
+        style={{
+          border: '2px dashed #ccc',
+          padding: '2rem',
+          textAlign: 'center',
+          cursor: 'pointer',
+        }}
+      >
+        <p>Drag & drop images here, or click to select</p>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={handleChange}
+          style={{ display: 'none' }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', marginTop: '1rem' }}>
+        {images.map((img, idx) => (
+          <img
+            key={idx}
+            src={img.url}
+            alt={img.name}
+            onClick={() => toggleSelect(idx)}
+            style={{
+              height: '150px',
+              width: 'auto',
+              marginRight: '1rem',
+              marginBottom: '1rem',
+              border: selected.includes(idx)
+                ? '4px solid #0070f3'
+                : '1px solid #ccc',
+              boxShadow: selected.includes(idx)
+                ? '0 0 5px #0070f3'
+                : 'none',
+              cursor: 'pointer',
+            }}
+          />
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance Next.js homepage with drag-and-drop image uploads
- preview uploaded images as selectable thumbnails
- keep thumbnail aspect ratio and highlight selected previews

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b43b151288323a06ce5bde0d9ce6e