### PR TITLE
Add stepwise puzzle workflow endpoints and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,16 @@ A lightweight Flask application exposes puzzle utilities. Start it with:
 python server.py
 ```
 
-By default it runs on port 5000 with an endpoint `/remove_background` that
-accepts an uploaded image and returns the segmented puzzle piece as base64.
+By default it runs on port 5000. Several endpoints are available that each
+perform one step of the workflow:
+
+- `/remove_background` – segment the puzzle piece and return the result and mask
+- `/detect_corners` – highlight detected corners on the piece
+- `/classify_piece` – return whether the piece is a corner, edge or middle piece
+- `/edge_descriptors` – compute simple metrics for each edge
+
+The included Next.js site provides buttons that call these endpoints
+individually so you can inspect the output of every stage.
 
 
 

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,54 +1,96 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export default function Home() {
-  const [images, setImages] = useState([]);
+  const [file, setFile] = useState(null);
+  const [result, setResult] = useState({});
 
-  const handleChange = async (e) => {
-    const files = Array.from(e.target.files);
-    const results = await Promise.all(
-      files.map(async (file) => {
-        const formData = new FormData();
-        formData.append('image', file);
-        const res = await fetch('http://localhost:5000/remove_background', {
-          method: 'POST',
-          body: formData,
-        });
-        const data = await res.json();
-        return {
-          url: `data:image/png;base64,${data.image}`,
-          name: file.name,
-        };
-      })
-    );
-    setImages((prev) => [...prev, ...results]);
-    e.target.value = null;
+  const handleFileChange = (e) => {
+    if (e.target.files.length > 0) {
+      setFile(e.target.files[0]);
+    }
   };
 
-  useEffect(() => {
-    return () => {
-      images.forEach((img) => {
-        if (img.url.startsWith('blob:')) {
-          URL.revokeObjectURL(img.url);
-        }
-      });
-    };
-  }, [images]);
+  const postImage = async (endpoint) => {
+    if (!file) return null;
+    const formData = new FormData();
+    formData.append('image', file);
+    const res = await fetch(`http://localhost:5000/${endpoint}`, {
+      method: 'POST',
+      body: formData,
+    });
+    return res.json();
+  };
+
+  const runRemoveBackground = async () => {
+    const data = await postImage('remove_background');
+    if (data) setResult((r) => ({ ...r, remove: data }));
+  };
+
+  const runDetectCorners = async () => {
+    const data = await postImage('detect_corners');
+    if (data) setResult((r) => ({ ...r, corners: data }));
+  };
+
+  const runClassifyPiece = async () => {
+    const data = await postImage('classify_piece');
+    if (data) setResult((r) => ({ ...r, type: data.type }));
+  };
+
+  const runEdgeDescriptors = async () => {
+    const data = await postImage('edge_descriptors');
+    if (data) setResult((r) => ({ ...r, descriptors: data.metrics }));
+  };
 
   return (
     <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
       <h1>Codex Puzzle</h1>
-      <p>Welcome to the puzzle application built with Next.js.</p>
-      <input type="file" accept="image/*" multiple onChange={handleChange} />
-      <div style={{ display: 'flex', flexWrap: 'wrap', marginTop: '1rem' }}>
-        {images.map((img, idx) => (
-          <img
-            key={idx}
-            src={img.url}
-            alt={img.name}
-            style={{ maxWidth: '200px', marginRight: '1rem', marginBottom: '1rem' }}
-          />
-        ))}
+      <input type="file" accept="image/*" onChange={handleFileChange} />
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={runRemoveBackground}>Remove Background</button>
+        <button onClick={runDetectCorners} style={{ marginLeft: '0.5rem' }}>
+          Detect Corners
+        </button>
+        <button onClick={runClassifyPiece} style={{ marginLeft: '0.5rem' }}>
+          Classify Piece
+        </button>
+        <button onClick={runEdgeDescriptors} style={{ marginLeft: '0.5rem' }}>
+          Edge Descriptors
+        </button>
       </div>
+      {result.remove && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Segmented Piece</h3>
+          <img
+            src={`data:image/png;base64,${result.remove.image}`}
+            alt="segmented"
+            style={{ maxWidth: '200px', marginRight: '1rem' }}
+          />
+          <img
+            src={`data:image/png;base64,${result.remove.mask}`}
+            alt="mask"
+            style={{ maxWidth: '200px' }}
+          />
+        </div>
+      )}
+      {result.corners && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Corners</h3>
+          <img
+            src={`data:image/png;base64,${result.corners.image}`}
+            alt="corners"
+            style={{ maxWidth: '200px' }}
+          />
+        </div>
+      )}
+      {result.type && (
+        <p style={{ marginTop: '1rem' }}>Piece Type: {result.type}</p>
+      )}
+      {result.descriptors && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Edge Descriptor Lengths</h3>
+          <pre>{JSON.stringify(result.descriptors, null, 2)}</pre>
+        </div>
+      )}
     </div>
   );
 }

--- a/server.py
+++ b/server.py
@@ -4,7 +4,13 @@ import cv2
 import numpy as np
 from flask import Flask, request, jsonify
 
-from puzzle.segmentation import remove_background
+from puzzle.segmentation import (
+    remove_background,
+    detect_piece_corners,
+    select_four_corners,
+    classify_piece_type,
+)
+from puzzle.features import extract_edge_descriptors
 
 app = Flask(__name__)
 
@@ -18,10 +24,69 @@ def remove_background_endpoint():
     img = cv2.imdecode(npimg, cv2.IMREAD_COLOR)
     if img is None:
         return jsonify({'error': 'Invalid image'}), 400
-    _mask, result = remove_background(img)
+    mask, result = remove_background(img)
     _, buf = cv2.imencode('.png', result)
-    b64 = base64.b64encode(buf).decode('utf-8')
-    return jsonify({'image': b64})
+    result_b64 = base64.b64encode(buf).decode('utf-8')
+    _, mask_buf = cv2.imencode('.png', mask * 255)
+    mask_b64 = base64.b64encode(mask_buf).decode('utf-8')
+    return jsonify({'image': result_b64, 'mask': mask_b64})
+
+
+@app.route('/detect_corners', methods=['POST'])
+def detect_corners_endpoint():
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image uploaded'}), 400
+    file = request.files['image']
+    data = file.read()
+    img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
+    if img is None:
+        return jsonify({'error': 'Invalid image'}), 400
+    mask, result = remove_background(img)
+    corners = detect_piece_corners(mask)
+    four = select_four_corners(corners)
+    overlay = result.copy()
+    for x, y in four:
+        cv2.circle(overlay, (int(x), int(y)), 4, (0, 0, 255), -1)
+    _, buf = cv2.imencode('.png', overlay)
+    overlay_b64 = base64.b64encode(buf).decode('utf-8')
+    return jsonify({'image': overlay_b64, 'corners': four.tolist()})
+
+
+@app.route('/classify_piece', methods=['POST'])
+def classify_piece_endpoint():
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image uploaded'}), 400
+    file = request.files['image']
+    data = file.read()
+    img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
+    if img is None:
+        return jsonify({'error': 'Invalid image'}), 400
+    mask, _ = remove_background(img)
+    corners = detect_piece_corners(mask)
+    four = select_four_corners(corners)
+    ptype = classify_piece_type(mask, four)
+    return jsonify({'type': ptype})
+
+
+@app.route('/edge_descriptors', methods=['POST'])
+def edge_descriptors_endpoint():
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image uploaded'}), 400
+    file = request.files['image']
+    data = file.read()
+    img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
+    if img is None:
+        return jsonify({'error': 'Invalid image'}), 400
+    mask, _ = remove_background(img)
+    corners = detect_piece_corners(mask)
+    four = select_four_corners(corners)
+    desc = extract_edge_descriptors(img, mask, four)
+    metrics = []
+    for d in desc:
+        hist_len = len(d['hist']) if d['hist'] is not None else 0
+        sift_len = len(d['sift']) if d['sift'] is not None else 0
+        metrics.append({'hist_len': hist_len, 'sift_len': sift_len})
+    return jsonify({'metrics': metrics})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add endpoints for corner detection, piece classification and descriptors
- extend `/remove_background` to return mask
- update README with new API endpoints
- create demo Next.js page with buttons for each workflow step

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b565b3d1883239e87afc4fc485948