### PR TITLE
Integrate FastAPI segmentation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,16 @@ The site will be available at `http://localhost:3000`.
 When deploying to Vercel, set the **Root Directory** to `frontend/` so that the
 platform can detect the Next.js project and build it correctly.
 
+## Python Backend
+
+A small FastAPI service is provided in `server.py` that exposes a `/segment`
+endpoint for puzzle piece segmentation. Start it with:
+
+```bash
+uvicorn server:app --reload
+```
+
+The frontend expects this service to run on `http://localhost:8000` when sending
+selected images for segmentation.
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ numpy
 pandas
 scikit-learn
 matplotlib
+fastapi
+uvicorn

--- a/server.py
+++ b/server.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+import cv2
+import numpy as np
+import base64
+from puzzle.segmentation import remove_background
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.post("/segment")
+async def segment(files: list[UploadFile] = File(...)):
+    results = []
+    for file in files:
+        data = await file.read()
+        arr = np.frombuffer(data, dtype=np.uint8)
+        img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+        if img is None:
+            continue
+        mask, piece = remove_background(img)
+        _, buf = cv2.imencode(".png", piece)
+        b64 = base64.b64encode(buf.tobytes()).decode("utf-8")
+        results.append({"name": file.filename, "pieces": [b64]})
+    return {"results": results}


### PR DESCRIPTION
## Summary
- implement simple FastAPI service in `server.py`
- allow frontend to submit selected images and display segmented pieces
- document backend usage
- add FastAPI dependencies

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7d97bb0c83239cf0e51e7c06c0a0