### PR TITLE
Fix front-end segment endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ individually so you can inspect the output of every stage.
 ## Additional Notes
 
 All puzzle processing endpoints are served from `server.py` using Flask on
-port `5000`. The `Segment Pieces` button in the frontend calls the
-`/segment_pieces` route to split an image containing multiple pieces into
-individual crops.
+port `5000`. The `Segment Pieces` and `Segment Selected` buttons in the
+frontend call the `/segment_pieces` route to split an image containing
+multiple pieces into individual crops. Be sure to start the Flask server
+with `python server.py` before using the Next.js interface.
 
 
 

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -121,7 +121,7 @@ export default function Home() {
       selected.forEach((idx) => {
         form.append('files', images[idx].file, images[idx].name);
       });
-      const res = await fetch('http://localhost:8000/segment', {
+      const res = await fetch('http://localhost:5000/segment_pieces', {
         method: 'POST',
         body: form,
       });


### PR DESCRIPTION
## Summary
- use the `/segment_pieces` endpoint on port 5000
- clarify Flask server usage in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8be8990c83239d181b1ebc578f23