### PR TITLE
Improve background removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ python server.py
 By default it runs on port 5000. Several endpoints are available that each
 perform one step of the workflow:
 
-- `/remove_background` – segment the puzzle piece and return the result and mask
-- `/detect_corners` – highlight detected corners on the piece
-- `/classify_piece` – return whether the piece is a corner, edge or middle piece
-- `/edge_descriptors` – compute simple metrics for each edge
+- `/remove_background` – segment the puzzle piece and return the result and mask. Optional `lower` and `upper` form fields provide grayscale thresholds for the background.
+- `/detect_corners` – highlight detected corners on the piece. Accepts the same `lower` and `upper` fields.
+- `/classify_piece` – return whether the piece is a corner, edge or middle piece. Accepts the same `lower` and `upper` fields.
+- `/edge_descriptors` – compute simple metrics for each edge. Accepts the same `lower` and `upper` fields.
 
 The included Next.js site provides buttons that call these endpoints
 individually so you can inspect the output of every stage.

--- a/server.py
+++ b/server.py
@@ -33,7 +33,22 @@ def remove_background_endpoint():
     img = cv2.imdecode(npimg, cv2.IMREAD_COLOR)
     if img is None:
         return jsonify({'error': 'Invalid image'}), 400
-    mask, result = remove_background(img)
+
+    try:
+        lower = int(request.form.get('lower', -1))
+    except ValueError:
+        lower = -1
+    try:
+        upper = int(request.form.get('upper', -1))
+    except ValueError:
+        upper = -1
+
+    lower_thresh = lower if lower >= 0 else None
+    upper_thresh = upper if upper >= 0 else None
+
+    mask, result = remove_background(
+        img, lower_thresh=lower_thresh, upper_thresh=upper_thresh
+    )
     _, buf = cv2.imencode('.png', result)
     result_b64 = base64.b64encode(buf).decode('utf-8')
     _, mask_buf = cv2.imencode('.png', mask * 255)
@@ -50,7 +65,21 @@ def detect_corners_endpoint():
     img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
     if img is None:
         return jsonify({'error': 'Invalid image'}), 400
-    mask, result = remove_background(img)
+
+    try:
+        lower = int(request.form.get('lower', -1))
+    except ValueError:
+        lower = -1
+    try:
+        upper = int(request.form.get('upper', -1))
+    except ValueError:
+        upper = -1
+    lower_thresh = lower if lower >= 0 else None
+    upper_thresh = upper if upper >= 0 else None
+
+    mask, result = remove_background(
+        img, lower_thresh=lower_thresh, upper_thresh=upper_thresh
+    )
     corners = detect_piece_corners(mask)
     four = select_four_corners(corners)
     overlay = result.copy()
@@ -70,7 +99,21 @@ def classify_piece_endpoint():
     img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
     if img is None:
         return jsonify({'error': 'Invalid image'}), 400
-    mask, _ = remove_background(img)
+
+    try:
+        lower = int(request.form.get('lower', -1))
+    except ValueError:
+        lower = -1
+    try:
+        upper = int(request.form.get('upper', -1))
+    except ValueError:
+        upper = -1
+    lower_thresh = lower if lower >= 0 else None
+    upper_thresh = upper if upper >= 0 else None
+
+    mask, _ = remove_background(
+        img, lower_thresh=lower_thresh, upper_thresh=upper_thresh
+    )
     corners = detect_piece_corners(mask)
     four = select_four_corners(corners)
     ptype = classify_piece_type(mask, four)
@@ -86,7 +129,21 @@ def edge_descriptors_endpoint():
     img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
     if img is None:
         return jsonify({'error': 'Invalid image'}), 400
-    mask, _ = remove_background(img)
+
+    try:
+        lower = int(request.form.get('lower', -1))
+    except ValueError:
+        lower = -1
+    try:
+        upper = int(request.form.get('upper', -1))
+    except ValueError:
+        upper = -1
+    lower_thresh = lower if lower >= 0 else None
+    upper_thresh = upper if upper >= 0 else None
+
+    mask, _ = remove_background(
+        img, lower_thresh=lower_thresh, upper_thresh=upper_thresh
+    )
     corners = detect_piece_corners(mask)
     four = select_four_corners(corners)
     desc = extract_edge_descriptors(img, mask, four)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,6 +1,6 @@
 import numpy as np
 import cv2
-from puzzle.segmentation import select_four_corners, segment_pieces
+from puzzle.segmentation import remove_background, select_four_corners, segment_pieces
 
 
 def test_select_four_corners_returns_four():
@@ -15,3 +15,10 @@ def test_segment_pieces_detects_regions():
     cv2.rectangle(img, (22, 2), (38, 18), (0, 0, 0), -1)
     pieces = segment_pieces(img, min_area=10)
     assert len(pieces) == 2
+
+
+def test_remove_background_with_threshold():
+    img = np.full((20, 20, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (5, 5), (14, 14), (0, 0, 0), -1)
+    mask, _ = remove_background(img, lower_thresh=240, upper_thresh=255, iter_count=1)
+    assert mask.max() == 1 and mask.min() == 0


### PR DESCRIPTION
## Summary
- create an optional threshold mask for GrabCut
- expose `lower` and `upper` form parameters on API endpoints
- document extra parameters
- improve GrabCut threshold behavior
- add regression test

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c5bd47d448323839cfe9b6a94b761