### PR TITLE
Add tests for segmentation improvements and endpoint parameters

### DIFF
--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -22,3 +22,26 @@ def test_remove_background_with_threshold():
     cv2.rectangle(img, (5, 5), (14, 14), (0, 0, 0), -1)
     mask, _ = remove_background(img, lower_thresh=240, upper_thresh=255, iter_count=1)
     assert mask.max() == 1 and mask.min() == 0
+
+
+def test_remove_background_custom_kernel_closes_holes():
+    img = np.full((20, 20, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (4, 4), (15, 15), (0, 0, 0), -1)
+    cv2.rectangle(img, (8, 8), (11, 11), (255, 255, 255), -1)
+    mask, _ = remove_background(
+        img,
+        lower_thresh=240,
+        upper_thresh=255,
+        kernel_size=5,
+        iter_count=1,
+    )
+    n_labels, _ = cv2.connectedComponents(mask)
+    assert n_labels == 2 and mask[9, 9] == 1
+
+
+def test_segment_pieces_preserves_separation_with_morphology():
+    img = np.full((20, 50, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (2, 2), (18, 18), (0, 0, 0), -1)
+    cv2.rectangle(img, (32, 2), (48, 18), (0, 0, 0), -1)
+    pieces = segment_pieces(img, min_area=10, thresh_val=240, kernel_size=5)
+    assert len(pieces) == 2

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,7 +16,15 @@ def test_remove_background_endpoint():
     client = app.test_client()
     img = np.full((10, 10, 3), 255, dtype=np.uint8)
     _, buf = cv2.imencode('.png', img)
-    response = client.post('/remove_background', data={'image': (io.BytesIO(buf.tobytes()), 'test.png')})
+    response = client.post(
+        '/remove_background',
+        data={
+            'image': (io.BytesIO(buf.tobytes()), 'test.png'),
+            'threshold_low': '240',
+            'threshold_high': '255',
+            'kernel_size': '3',
+        },
+    )
     assert response.status_code == 200
     data = json.loads(response.data)
     assert 'image' in data and 'mask' in data


### PR DESCRIPTION
## Summary
- extend segmentation tests with hole closing and morphological separation checks
- send parameters in remove_background endpoint test

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8b9842d083238ddc1ab6fc3ec2e1