### PR TITLE
Add PuzzlePiece dataclass with metadata segmentation

### DIFF
--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -5,6 +5,8 @@ from .segmentation import (
     is_edge_straight,
     classify_piece_type,
     segment_pieces,
+    segment_pieces_metadata,
+    PuzzlePiece,
 )
 from .features import extract_edge_descriptors
 from .assembly import render_puzzle
@@ -16,6 +18,8 @@ __all__ = [
     "is_edge_straight",
     "classify_piece_type",
     "segment_pieces",
+    "segment_pieces_metadata",
+    "PuzzlePiece",
     "extract_edge_descriptors",
     "render_puzzle",
 ]


### PR DESCRIPTION
## Summary
- implement `PuzzlePiece` dataclass
- create `segment_pieces_metadata` for cropping with metadata
- export in package API
- add Flask endpoint returning piece data and metadata
- test segmentation metadata

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8cd02b6c8323b11ed9bce131c8a4