### PR TITLE
Enhance feature extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ perform one step of the workflow:
 The included Next.js site provides buttons that call these endpoints
 individually so you can inspect the output of every stage.
 
+## Feature Extraction Pipeline
+
+Each puzzle edge is analyzed to produce several descriptors:
+
+- **Edge type** – labeled as `tab`, `hole` or `flat` by comparing the piece
+  contour to its convex hull.
+- **Color histogram** – HSV histogram sampled from a thin strip along the edge.
+- **Hu moments** – shape moments of the same edge segment capturing its curve.
+- **Color profile** – average HSV values across that strip.
+
+The dataclasses `EdgeFeatures` and `PieceFeatures` store these metrics for each
+piece. `extract_edge_descriptors` returns dictionaries containing the vectors for
+all four edges in order.
+
 ## Additional Notes
 
 All puzzle processing endpoints are served from `server.py` using Flask on

--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -8,7 +8,12 @@ from .segmentation import (
     segment_pieces_metadata,
     PuzzlePiece,
 )
-from .features import extract_edge_descriptors
+from .features import (
+    extract_edge_descriptors,
+    classify_edge_types,
+    EdgeFeatures,
+    PieceFeatures,
+)
 from .assembly import render_puzzle
 
 __all__ = [
@@ -21,5 +26,8 @@ __all__ = [
     "segment_pieces_metadata",
     "PuzzlePiece",
     "extract_edge_descriptors",
+    "classify_edge_types",
+    "EdgeFeatures",
+    "PieceFeatures",
     "render_puzzle",
 ]

--- a/puzzle/features.py
+++ b/puzzle/features.py
@@ -1,5 +1,28 @@
 import cv2
 import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class EdgeFeatures:
+    """Structure holding measurements for a single edge."""
+
+    edge_type: str
+    length: float
+    angle: float
+    hu_moments: np.ndarray | None
+    color_hist: np.ndarray | None
+    color_profile: np.ndarray | None
+
+
+@dataclass
+class PieceFeatures:
+    """Collection of contour level metrics for an entire piece."""
+
+    contour: np.ndarray
+    area: float
+    bbox: tuple[int, int, int, int]
+    edges: list[EdgeFeatures]
 
 
 def _edge_strip_mask(mask, pt1, pt2, width):
@@ -74,6 +97,68 @@ def _sift_descriptors(img, mask):
     return desc.mean(axis=0)
 
 
+def classify_edge_types(contour, corners):
+    """Label edges as ``tab``, ``hole`` or ``flat`` using convexity analysis."""
+
+    if contour.ndim == 3:
+        contour = contour[:, 0, :]
+
+    hull_idx = cv2.convexHull(contour, returnPoints=False)
+    hull_pts = cv2.convexHull(contour, returnPoints=True)[:, 0, :]
+    defects = cv2.convexityDefects(contour, hull_idx)
+
+    def _nearest_idx(pt):
+        d = np.linalg.norm(contour - pt, axis=1)
+        return int(np.argmin(d))
+
+    def _segment(points, i1, i2):
+        if i1 <= i2:
+            return points[i1 : i2 + 1]
+        return np.vstack((points[i1:], points[: i2 + 1]))
+
+    def _arc_length(points, i1, i2):
+        seg = _segment(points, i1, i2)
+        return cv2.arcLength(seg, False)
+
+    labels = []
+    for i in range(4):
+        p1 = corners[i]
+        p2 = corners[(i + 1) % 4]
+        idx1 = _nearest_idx(p1)
+        idx2 = _nearest_idx(p2)
+        seg = _segment(contour, idx1, idx2)
+        h1 = np.argmin(np.linalg.norm(hull_pts - p1, axis=1))
+        h2 = np.argmin(np.linalg.norm(hull_pts - p2, axis=1))
+        hull_order = hull_idx.squeeze()
+
+        if h1 <= h2:
+            num_hull_vertices = h2 - h1
+        else:
+            num_hull_vertices = len(hull_order) - (h1 - h2)
+
+        is_hole = False
+        if defects is not None:
+            for d in defects[:, 0]:
+                start, end = d[0], d[1]
+                if idx1 <= idx2:
+                    if start >= idx1 and end <= idx2:
+                        is_hole = True
+                        break
+                else:
+                    if start >= idx1 or end <= idx2:
+                        is_hole = True
+                        break
+
+        if is_hole:
+            labels.append("hole")
+        elif num_hull_vertices > 1:
+            labels.append("tab")
+        else:
+            labels.append("flat")
+
+    return labels
+
+
 def extract_edge_descriptors(image, mask, corners, edge_width: int = 15, hist_bins: int = 8):
     """Compute descriptors for each edge of a piece.
 
@@ -93,17 +178,27 @@ def extract_edge_descriptors(image, mask, corners, edge_width: int = 15, hist_bi
     Returns
     -------
     list[dict]
-        A list of dictionaries with keys 'hist' and 'sift' for each edge.
+        A list of dictionaries describing each edge. Keys include 'hist',
+        'sift', 'hu' and 'color_profile'.
     """
     descriptors = []
+    hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
     for i in range(4):
         pt1 = corners[i]
         pt2 = corners[(i + 1) % 4]
         strip_mask = _edge_strip_mask(mask, pt1, pt2, edge_width)
         if np.count_nonzero(strip_mask) == 0:
-            descriptors.append({'hist': None, 'sift': None})
+            descriptors.append({'hist': None, 'sift': None, 'hu': None, 'color_profile': None})
             continue
         hist = _color_histogram(image, strip_mask * 255, bins=hist_bins)
         sift = _sift_descriptors(image, strip_mask * 255)
-        descriptors.append({'hist': hist, 'sift': sift})
+
+        moments = cv2.moments(strip_mask)
+        hu = cv2.HuMoments(moments).flatten()
+
+        # Average HSV values along the edge strip as a simple color profile
+        colors = hsv[strip_mask.astype(bool)]
+        profile = colors.mean(axis=0) if colors.size else None
+
+        descriptors.append({'hist': hist, 'sift': sift, 'hu': hu, 'color_profile': profile})
     return descriptors

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,6 +1,11 @@
 import numpy as np
 import cv2
-from puzzle.features import extract_edge_descriptors
+from puzzle.features import (
+    extract_edge_descriptors,
+    classify_edge_types,
+    EdgeFeatures,
+    PieceFeatures,
+)
 
 
 def test_extract_edge_descriptors_simple_square():
@@ -11,3 +16,28 @@ def test_extract_edge_descriptors_simple_square():
     assert len(desc) == 4
     for d in desc:
         assert 'hist' in d and 'sift' in d
+        assert 'hu' in d and 'color_profile' in d
+        if d['hu'] is not None:
+            assert len(d['hu']) == 7
+        if d['color_profile'] is not None:
+            assert len(d['color_profile']) == 3
+
+
+def test_classify_edge_types_tab_and_hole():
+    contour_tab = np.array([[0, 0], [10, 0], [12, 5], [10, 10], [0, 10]], dtype=np.int32)
+    corners_tab = np.array([[0, 0], [10, 0], [10, 10], [0, 10]], dtype=np.int32)
+    labels_tab = classify_edge_types(contour_tab, corners_tab)
+    assert labels_tab == ["flat", "tab", "flat", "flat"]
+
+    contour_hole = np.array(
+        [[0, 0], [10, 0], [10, 10], [6, 10], [6, 8], [4, 8], [4, 10], [0, 10]], dtype=np.int32
+    )
+    corners_hole = np.array([[0, 0], [10, 0], [10, 10], [0, 10]], dtype=np.int32)
+    labels_hole = classify_edge_types(contour_hole, corners_hole)
+    assert labels_hole == ["flat", "flat", "hole", "flat"]
+
+
+def test_edge_and_piece_dataclasses():
+    e = EdgeFeatures(edge_type="flat", length=10.0, angle=0.0, hu_moments=None, color_hist=None, color_profile=None)
+    p = PieceFeatures(contour=np.zeros((1, 2), dtype=np.int32), area=0.0, bbox=(0, 0, 1, 1), edges=[e])
+    assert p.edges[0].edge_type == "flat"


### PR DESCRIPTION
## Summary
- add EdgeFeatures and PieceFeatures dataclasses
- implement `classify_edge_types` using convex hull/defects
- extend `extract_edge_descriptors` with Hu moments and color profile
- document new feature extraction pipeline in README
- test dataclasses, edge classification and new descriptors

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8f13ccb08323b1c7c6fef64f9956