### PR TITLE
Add scoring utilities with tests

### DIFF
--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -17,6 +17,11 @@ from .features import (
     PieceFeatures,
 )
 from .assembly import render_puzzle
+from .scoring import (
+    shape_similarity,
+    color_similarity,
+    compatibility_score,
+)
 
 __all__ = [
     "remove_background",
@@ -34,4 +39,7 @@ __all__ = [
     "EdgeFeatures",
     "PieceFeatures",
     "render_puzzle",
+    "shape_similarity",
+    "color_similarity",
+    "compatibility_score",
 ]

--- a/puzzle/scoring.py
+++ b/puzzle/scoring.py
@@ -1,0 +1,55 @@
+import cv2
+import numpy as np
+
+from .features import EdgeFeatures
+
+
+def shape_similarity(edge_a: EdgeFeatures, edge_b: EdgeFeatures) -> float:
+    """Return a distance between two edges based on Hu moments."""
+    if edge_a.hu_moments is None or edge_b.hu_moments is None:
+        return float("inf")
+    # Ensure arrays are float32 for cv2.norm
+    a = edge_a.hu_moments.astype(np.float32)
+    b = edge_b.hu_moments.astype(np.float32)
+    return float(cv2.norm(a, b))
+
+
+def color_similarity(edge_a: EdgeFeatures, edge_b: EdgeFeatures) -> float:
+    """Return a distance between edge colors using histograms or HSV profiles."""
+    if edge_a.color_hist is not None and edge_b.color_hist is not None:
+        h1 = edge_a.color_hist.astype(np.float32)
+        h2 = edge_b.color_hist.astype(np.float32)
+        return float(cv2.compareHist(h1, h2, cv2.HISTCMP_BHATTACHARYYA))
+
+    if edge_a.color_profile is not None and edge_b.color_profile is not None:
+        p1 = edge_a.color_profile.astype(np.float32)
+        p2 = edge_b.color_profile.astype(np.float32)
+        return float(cv2.norm(p1, p2))
+
+    return float("inf")
+
+
+_VALID_PAIRS = {
+    ("tab", "hole"),
+    ("hole", "tab"),
+    ("flat", "flat"),
+}
+
+
+def compatibility_score(
+    edge_a: EdgeFeatures,
+    edge_b: EdgeFeatures,
+    weight_shape: float = 2.0,
+    weight_color: float = 1.0,
+) -> float:
+    """Combine shape and color metrics for a matching score."""
+    if (edge_a.edge_type, edge_b.edge_type) not in _VALID_PAIRS:
+        return float("inf")
+
+    s_shape = shape_similarity(edge_a, edge_b)
+    s_color = color_similarity(edge_a, edge_b)
+
+    if np.isinf(s_shape) or np.isinf(s_color):
+        return float("inf")
+
+    return weight_shape * s_shape + weight_color * s_color

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,34 @@
+import numpy as np
+from puzzle.scoring import shape_similarity, color_similarity, compatibility_score
+from puzzle.features import EdgeFeatures
+
+
+def _edge(edge_type, hu, color):
+    return EdgeFeatures(
+        edge_type=edge_type,
+        length=1.0,
+        angle=0.0,
+        hu_moments=np.array(hu, dtype=np.float32),
+        color_hist=None,
+        color_profile=np.array(color, dtype=np.float32),
+    )
+
+
+def test_identical_edges_score_lower():
+    tab = _edge("tab", [0.5] * 7, [10, 20, 30])
+    hole_same = _edge("hole", [0.5] * 7, [10, 20, 30])
+    hole_diff = _edge("hole", [2.0] * 7, [0, 0, 0])
+
+    good = compatibility_score(tab, hole_same)
+    bad = compatibility_score(tab, hole_diff)
+
+    assert good < bad
+
+
+def test_incompatible_edge_types():
+    tab1 = _edge("tab", [0.5] * 7, [10, 20, 30])
+    tab2 = _edge("tab", [0.5] * 7, [10, 20, 30])
+    hole = _edge("hole", [0.5] * 7, [10, 20, 30])
+
+    assert compatibility_score(tab1, hole) < float("inf")
+    assert compatibility_score(tab1, tab2) == float("inf")


### PR DESCRIPTION
## Summary
- implement `shape_similarity`, `color_similarity`, `compatibility_score`
- expose scoring helpers in package init
- test scoring logic

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c988a1b4c832393861d5ade49e808