### PR TITLE
Add top_n_matches scoring utility

### DIFF
--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -21,6 +21,7 @@ from .scoring import (
     shape_similarity,
     color_similarity,
     compatibility_score,
+    top_n_matches,
 )
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "shape_similarity",
     "color_similarity",
     "compatibility_score",
+    "top_n_matches",
 ]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,6 +1,6 @@
 import numpy as np
-from puzzle.scoring import shape_similarity, color_similarity, compatibility_score
-from puzzle.features import EdgeFeatures
+from puzzle.scoring import shape_similarity, color_similarity, compatibility_score, top_n_matches
+from puzzle.features import EdgeFeatures, PieceFeatures
 
 
 def _edge(edge_type, hu, color):
@@ -11,6 +11,15 @@ def _edge(edge_type, hu, color):
         hu_moments=np.array(hu, dtype=np.float32),
         color_hist=None,
         color_profile=np.array(color, dtype=np.float32),
+    )
+
+
+def _piece(edges):
+    return PieceFeatures(
+        contour=np.zeros((1, 2), dtype=np.int32),
+        area=0.0,
+        bbox=(0, 0, 1, 1),
+        edges=edges,
     )
 
 
@@ -32,3 +41,19 @@ def test_incompatible_edge_types():
 
     assert compatibility_score(tab1, hole) < float("inf")
     assert compatibility_score(tab1, tab2) == float("inf")
+
+
+def test_top_n_matches_finds_best_partner():
+    tab_good = _edge("tab", [0.1] * 7, [1, 2, 3])
+    tab_other = _edge("tab", [2.0] * 7, [5, 5, 5])
+    piece_a = _piece([tab_good, _edge("flat", [0] * 7, [0, 0, 0]), tab_other, _edge("flat", [0] * 7, [0, 0, 0])])
+
+    hole_match = _edge("hole", [0.1] * 7, [1, 2, 3])
+    hole_other = _edge("hole", [3.0] * 7, [10, 10, 10])
+    piece_b = _piece([hole_match, hole_other, _edge("tab", [0] * 7, [0, 0, 0]), _edge("flat", [0] * 7, [0, 0, 0])])
+
+    results = top_n_matches([piece_a, piece_b], n=1)
+
+    assert (0, 0) in results
+    match = results[(0, 0)][0]
+    assert match[0] == 1 and match[1] == 0


### PR DESCRIPTION
## Summary
- add new function `top_n_matches` to compute best edge matches across pieces
- export the function in the package
- test the new function in scoring tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c99971e948323948e03704d55628d