### PR TITLE
Remove duplicate segmentation button

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -216,7 +216,6 @@ export default function Home() {
 
       <div className="buttons" style={{ marginTop: '1rem' }}>
         <button onClick={runRemoveBackground} disabled={loading}>Remove Background</button>
-        <button onClick={runRemoveBackground} disabled={loading}>Foreground Segmentation</button>
         <button onClick={runDetectCorners} disabled={loading}>Detect Corners</button>
         <button onClick={runClassifyPiece} disabled={loading}>Classify Piece</button>
         <button onClick={runEdgeDescriptors} disabled={loading}>Edge Descriptors</button>


### PR DESCRIPTION
## Summary
- remove "Foreground Segmentation" button from the Next.js interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9a15c7008323a828863056b1b55a