### PR TITLE
Implement median-based puzzle segmentation

### DIFF
--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -7,6 +7,7 @@ from .segmentation import (
     detect_orientation,
     rotate_piece,
     segment_pieces,
+    segment_pieces_by_median,
     segment_pieces_metadata,
     PuzzlePiece,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "detect_orientation",
     "rotate_piece",
     "segment_pieces",
+    "segment_pieces_by_median",
     "segment_pieces_metadata",
     "PuzzlePiece",
     "extract_edge_descriptors",

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -5,6 +5,7 @@ from puzzle.segmentation import (
     remove_background,
     select_four_corners,
     segment_pieces,
+    segment_pieces_by_median,
     segment_pieces_metadata,
     detect_orientation,
     PuzzlePiece,
@@ -102,3 +103,23 @@ def test_rotated_piece_normalized_angle_correct():
     if rect[1][0] < rect[1][1]:
         ang += 90
     assert pytest.approx(ang % 90, abs=1) == 0
+
+
+def test_segment_pieces_by_median_filters_by_area():
+    img = np.full((40, 80, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (2, 2), (11, 11), (0, 0, 0), -1)
+    cv2.rectangle(img, (22, 2), (31, 11), (0, 0, 0), -1)
+    cv2.rectangle(img, (42, 2), (61, 21), (0, 0, 0), -1)
+    pieces = segment_pieces_by_median(img, thresh_val=240)
+    assert len(pieces) == 2
+
+
+def test_segment_pieces_by_median_returns_contour_only():
+    img = np.full((30, 30, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (5, 5), (14, 14), (0, 0, 0), -1)
+    pieces = segment_pieces_by_median(img, thresh_val=240)
+    assert len(pieces) == 1
+    piece = pieces[0]
+    gray = cv2.cvtColor(piece, cv2.COLOR_BGR2GRAY)
+    h, w = gray.shape
+    assert np.all(gray[1 : h - 1, 1 : w - 1] == 0)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -90,3 +90,17 @@ def test_compare_edges_endpoint():
     data = json.loads(response.data)
     assert 'score' in data
     assert isinstance(data['score'], (int, float))
+
+
+def test_extract_filtered_pieces_endpoint():
+    app = server.app
+    client = app.test_client()
+    img = np.full((40, 80, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (2, 2), (11, 11), (0, 0, 0), -1)
+    cv2.rectangle(img, (22, 2), (31, 11), (0, 0, 0), -1)
+    cv2.rectangle(img, (42, 2), (61, 21), (0, 0, 0), -1)
+    _, buf = cv2.imencode('.png', img)
+    response = client.post('/extract_filtered_pieces', data={'image': (io.BytesIO(buf.tobytes()), 't.png')})
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert 'pieces' in data and len(data['pieces']) == 2


### PR DESCRIPTION
## Summary
- add `segment_pieces_by_median` in segmentation module
- expose the new function from `puzzle.__init__`
- add `/extract_filtered_pieces` endpoint in server
- unit tests for new segmentation and endpoint

## Testing
- `./setup.sh`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca0603b58832386675f06f0ce6bc6