### PR TITLE
Add canvas layout & merge features

### DIFF
--- a/server.py
+++ b/server.py
@@ -331,8 +331,8 @@ def segment_pieces_metadata_endpoint():
     return jsonify({'pieces': outputs})
 
 
-@app.route('/extract_filtered_pieces', methods=['POST'])
-def extract_filtered_pieces_endpoint():
+@app.route('/piece_contours', methods=['POST'])
+def piece_contours_endpoint():
     if 'image' not in request.files:
         return jsonify({'error': 'No image uploaded'}), 400
     file = request.files['image']


### PR DESCRIPTION
## Summary
- resolve duplicate endpoint name in server
- persist canvas layout in localStorage and render items on a board
- add `/merge_pieces` and `/undo_merge` hooks in the frontend for updating the canvas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca28390bc83238ff3416160293710