### PR TITLE
Add reinforcement learning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ and opening step to smooth shapes and accepts optional `threshold` and
 `kernel_size` parameters. Be sure to start the Flask server with
 `python server.py` before using the Next.js interface.
 
+## Reinforcement Learning Trainer
+
+Feedback from the UI is stored in `feedback.jsonl`. To update the policy run:
+
+```bash
+python train_rl.py
+```
+
+This uses Stable Baselines3 to train a PPO model and saves the weights to
+`rl_model.zip`.
+
 
 
 

--- a/puzzle/rl_env.py
+++ b/puzzle/rl_env.py
@@ -1,0 +1,60 @@
+import json
+import random
+from typing import Any, Dict, List
+
+import gymnasium as gym
+from gymnasium import spaces
+
+
+class PuzzleEnv(gym.Env):
+    """Minimal environment using logged feedback as transitions."""
+
+    metadata = {"render.modes": []}
+
+    def __init__(self, feedback: List[Dict[str, Any]]):
+        super().__init__()
+        self.feedback = feedback
+
+        # Group rewards by serialized state
+        self._state_actions: Dict[str, Dict[Any, float]] = {}
+        states = []
+        for entry in feedback:
+            key = json.dumps(entry["state"], sort_keys=True)
+            states.append(key)
+            acts = self._state_actions.setdefault(key, {})
+            acts[entry["action"]] = entry.get("reward", 0.0)
+
+        self._states = sorted(set(states))
+        self._actions = sorted({e["action"] for e in feedback})
+
+        self.observation_space = spaces.Discrete(len(self._states))
+        self.action_space = spaces.Discrete(len(self._actions))
+        self.state_index = 0
+
+    @property
+    def current_state(self) -> Dict[str, Any]:
+        return json.loads(self._states[self.state_index])
+
+    def available_actions(self) -> List[Any]:
+        key = self._states[self.state_index]
+        return list(self._state_actions.get(key, {}).keys())
+
+    def reset(self, *, seed: int | None = None, options: Dict[str, Any] | None = None):
+        super().reset(seed=seed)
+        self.state_index = random.randrange(len(self._states))
+        observation = self.state_index
+        info = {}
+        return observation, info
+
+    def step(self, action: int):
+        assert self.action_space.contains(action)
+        action_value = self._actions[action]
+        key = self._states[self.state_index]
+        reward = float(self._state_actions.get(key, {}).get(action_value, 0.0))
+        terminated = True
+        truncated = False
+        info: Dict[str, Any] = {}
+        # sample next state randomly
+        self.state_index = random.randrange(len(self._states))
+        observation = self.state_index
+        return observation, reward, terminated, truncated, info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "scikit-learn",
     "matplotlib",
     "flask-cors",
+    "stable-baselines3",
+    "gymnasium",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ fastapi
 uvicorn
 flask
 flask-cors
+stable-baselines3
+gymnasium

--- a/train_rl.py
+++ b/train_rl.py
@@ -1,0 +1,43 @@
+import json
+import os
+
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+from puzzle.rl_env import PuzzleEnv
+
+
+FEEDBACK_FILE = "feedback.jsonl"
+MODEL_FILE = "rl_model"
+
+
+def load_feedback(path: str) -> list[dict]:
+    if not os.path.exists(path):
+        return []
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def main(total_timesteps: int = 1000):
+    feedback = load_feedback(FEEDBACK_FILE)
+    if not feedback:
+        print("No feedback data found.")
+        return
+
+    def _make_env():
+        return PuzzleEnv(feedback)
+
+    env = DummyVecEnv([_make_env])
+
+    if os.path.exists(MODEL_FILE + ".zip"):
+        model = PPO.load(MODEL_FILE, env=env)
+    else:
+        model = PPO("MlpPolicy", env, verbose=1)
+
+    model.learn(total_timesteps=total_timesteps)
+    model.save(MODEL_FILE)
+    print(f"Model saved to {MODEL_FILE}.zip")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a lightweight `PuzzleEnv` compatible with Gymnasium
- create `train_rl.py` to train PPO policy from feedback
- include stable-baselines3 and gymnasium in dependencies
- document training procedure in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(successful)*
- `pip install opencv-python-headless pandas scikit-learn matplotlib flask-cors stable-baselines3 gymnasium fastapi uvicorn flask` *(incomplete due to interruption)*

------
https://chatgpt.com/codex/tasks/task_e_684cd4a8ca7c8323956163a954d26063