### PR TITLE
Fix compile error and optional RL imports

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -424,8 +424,6 @@ export default function Home() {
           ))}
         </div>
       )}
-
-      <div
       <div
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}

--- a/puzzle/rl_env.py
+++ b/puzzle/rl_env.py
@@ -2,16 +2,22 @@ import json
 import random
 from typing import Any, Dict, List
 
-import gymnasium as gym
-from gymnasium import spaces
+try:
+    import gymnasium as gym
+    from gymnasium import spaces
+except Exception:  # pragma: no cover - optional dependency
+    gym = None
+    spaces = None
 
 
-class PuzzleEnv(gym.Env):
+class PuzzleEnv(gym.Env if gym is not None else object):
     """Minimal environment using logged feedback as transitions."""
 
     metadata = {"render.modes": []}
 
     def __init__(self, feedback: List[Dict[str, Any]]):
+        if gym is None or spaces is None:
+            raise ImportError("gymnasium is required for PuzzleEnv")
         super().__init__()
         self.feedback = feedback
 


### PR DESCRIPTION
## Summary
- fix Next.js drag-and-drop markup
- make RL modules optional so the API can load without heavy dependencies
- guard PuzzleEnv import when gymnasium isn't installed

## Testing
- `pytest -q` *(fails: remove_background_endpoint returns 422 due to multipart issues)*

------
https://chatgpt.com/codex/tasks/task_e_684cdeddd08083238aa98272942aa47b