### PR TITLE
Add convex hull option to segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ perform one step of the workflow:
 - `/classify_piece` – return whether the piece is a corner, edge or middle piece. Accepts the same `lower` and `upper` fields.
 - `/edge_descriptors` – compute simple metrics for each edge. Accepts the same `lower` and `upper` fields.
 - `/segment_pieces` – split an image containing several pieces into
-  individual crops. Optional `threshold` and `kernel_size` fields control the
-  binary threshold and smoothing kernel size used during detection.
+  individual crops. Optional `threshold`, `kernel_size` and `use_hull`
+  fields control the binary threshold, smoothing kernel size and whether
+  bounding boxes use the contour convex hull.
 
 The included Next.js site provides buttons that call these endpoints
 individually so you can inspect the output of every stage.
@@ -118,8 +119,8 @@ All puzzle processing endpoints are served from `server.py` using Flask on
 port `5000`. The `Segment Pieces` and `Segment Selected` buttons in the
 frontend call the `/segment_pieces` route to split an image containing
 multiple pieces into individual crops. The route now applies a closing
-and opening step to smooth shapes and accepts optional `threshold` and
-`kernel_size` parameters. Be sure to start the Flask server with
+and opening step to smooth shapes and accepts optional `threshold`,
+`kernel_size` and `use_hull` parameters. Be sure to start the Flask server with
 `python server.py` before using the Next.js interface.
 
 ## Reinforcement Learning Trainer

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -21,6 +21,7 @@ export default function Home() {
   const [thresholdHigh, setThresholdHigh] = useState('');
   const [kernelSize, setKernelSize] = useState('');
   const [minArea, setMinArea] = useState('100');
+  const [useHull, setUseHull] = useState(false);
   const [contourCount, setContourCount] = useState(null);
   // canvas with placed pieces and groups
   const [canvasItems, setCanvasItems] = useState([]);
@@ -155,7 +156,10 @@ export default function Home() {
   const runSegmentPieces = async () => {
     setLoading(true);
     try {
-      const data = await postImage('segment_pieces', file, { min_area: minArea });
+      const data = await postImage('segment_pieces', file, {
+        min_area: minArea,
+        use_hull: useHull,
+      });
       if (data && data.pieces) {
         setPieces(data.pieces);
         setContourCount(data.num_contours);
@@ -193,6 +197,7 @@ export default function Home() {
         const form = new FormData();
         form.append('image', images[idx].file, images[idx].name);
         form.append('min_area', minArea);
+        form.append('use_hull', useHull);
         const res = await fetch('http://localhost:5000/segment_pieces', {
           method: 'POST',
           body: form,
@@ -499,6 +504,15 @@ export default function Home() {
             onChange={(e) => setMinArea(e.target.value)}
             style={{ marginLeft: '0.5rem', width: '80px' }}
           />
+        </label>
+        <label style={{ marginLeft: '1rem' }}>
+          <input
+            type="checkbox"
+            checked={useHull}
+            onChange={(e) => setUseHull(e.target.checked)}
+            style={{ marginRight: '0.25rem' }}
+          />
+          Use Hull
         </label>
       </div>
 

--- a/puzzle/api/segmentation_api.py
+++ b/puzzle/api/segmentation_api.py
@@ -61,6 +61,7 @@ async def segment_pieces_endpoint(
     C: int | None = Form(None),
     threshold1: int | None = Form(None),
     threshold2: int | None = Form(None),
+    use_hull: bool = Form(False),
 ):
     data = await image.read()
     img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
@@ -72,6 +73,7 @@ async def segment_pieces_endpoint(
         thresh_val=threshold,
         kernel_size=kernel_size,
         method=method,
+        use_hull=use_hull,
         block_size=block_size,
         C=C,
         threshold1=threshold1,

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -59,6 +59,23 @@ def test_segment_pieces_preserves_separation_with_morphology():
     assert len(pieces) == 2
 
 
+def test_segment_pieces_use_hull():
+    img = np.full((20, 20, 3), 255, dtype=np.uint8)
+    contour = np.array([[2, 2], [18, 2], [18, 10], [10, 10], [10, 18], [2, 18]])
+    cv2.drawContours(img, [contour], -1, (0, 0, 0), -1)
+    pieces1, _ = segment_pieces(img, min_area=10, use_hull=False)
+    pieces2, _ = segment_pieces(img, min_area=10, use_hull=True)
+    assert len(pieces1) == len(pieces2) == 1
+
+
+def test_segment_pieces_metadata_use_hull():
+    img = np.full((20, 20, 3), 255, dtype=np.uint8)
+    contour = np.array([[2, 2], [18, 2], [18, 10], [10, 10], [10, 18], [2, 18]])
+    cv2.drawContours(img, [contour], -1, (0, 0, 0), -1)
+    pieces = segment_pieces_metadata(img, min_area=10, normalize=False, use_hull=True)
+    assert len(pieces) == 1 and isinstance(pieces[0], PuzzlePiece)
+
+
 def test_segment_pieces_metadata_returns_objects():
     img = np.full((20, 40, 3), 255, dtype=np.uint8)
     cv2.rectangle(img, (2, 2), (18, 18), (0, 0, 0), -1)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,6 +51,14 @@ def test_segment_pieces_endpoint():
     )
     data = response.json()
     assert len(data["pieces"]) == 0 and data["num_contours"] == 2
+    # ensure use_hull parameter is accepted
+    response = client.post(
+        "/segment_pieces",
+        data={"image": (io.BytesIO(buf.tobytes()), "test.png"), "use_hull": "true"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["pieces"]) == 2
 
 
 def test_adjust_image_endpoint():


### PR DESCRIPTION
## Summary
- add `use_hull` parameter to `segment_pieces` and `segment_pieces_metadata`
- support the flag in the `/segment_pieces` API
- surface a checkbox in the Next.js frontend
- document the new option in README
- extend tests for API and segmentation functions

## Testing
- `pip install -e .` *(fails: network access required for dependencies)*
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'numpy'`)*

------
https://chatgpt.com/codex/tasks/task_e_684cef1ebc608323964d27c170f5ec02