### PR TITLE
Add mask contour extraction feature

### DIFF
--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -9,6 +9,7 @@ from .segmentation import (
     segment_pieces,
     segment_pieces_by_median,
     segment_pieces_metadata,
+    extract_mask_contours,
     PuzzlePiece,
 )
 from .features import (
@@ -37,6 +38,7 @@ __all__ = [
     "segment_pieces",
     "segment_pieces_by_median",
     "segment_pieces_metadata",
+    "extract_mask_contours",
     "PuzzlePiece",
     "extract_edge_descriptors",
     "classify_edge_types",

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -9,6 +9,7 @@ from puzzle.segmentation import (
     segment_pieces_by_median,
     segment_pieces_metadata,
     detect_orientation,
+    extract_mask_contours,
     PuzzlePiece,
 )
 
@@ -167,3 +168,13 @@ def test_apply_threshold_canny():
     out = apply_threshold(img, method="canny", threshold1=50, threshold2=100)
     assert out.shape == img.shape[:2]
     assert out.dtype == np.uint8
+
+
+def test_extract_mask_contours_filters_by_area():
+    mask = np.zeros((40, 80), dtype=np.uint8)
+    cv2.rectangle(mask, (2, 2), (11, 11), 255, -1)
+    cv2.rectangle(mask, (22, 2), (31, 11), 255, -1)
+    cv2.rectangle(mask, (42, 2), (45, 5), 255, -1)
+    pieces, num = extract_mask_contours(mask)
+    assert num == 3
+    assert len(pieces) == 2

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -130,6 +130,23 @@ def test_extract_filtered_pieces_endpoint():
     assert "pieces" in data and len(data["pieces"]) == 0
 
 
+def test_mask_contours_endpoint():
+    app = server.app
+    client = TestClient(app)
+    mask = np.zeros((20, 40), dtype=np.uint8)
+    cv2.rectangle(mask, (2, 2), (8, 18), 255, -1)
+    cv2.rectangle(mask, (22, 2), (38, 18), 255, -1)
+    _, buf = cv2.imencode(".png", mask)
+    response = client.post(
+        "/mask_contours", data={"image": (io.BytesIO(buf.tobytes()), "mask.png")}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "contours" in data and "num_contours" in data
+    assert data["num_contours"] == 2
+    assert len(data["contours"]) == 2
+
+
 def _dummy_features(size):
     h, w = size
     contour = np.array([[0, 0], [w - 1, 0], [w - 1, h - 1], [0, h - 1]], dtype=np.int32)


### PR DESCRIPTION
## Summary
- invert mask output in remove_background API endpoint
- add `extract_mask_contours` helper to find large contours in a mask
- expose new `/mask_contours` endpoint for extracting those contours
- export new helper in `puzzle.__init__`
- test mask contour extraction and endpoint

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pip install httpx`
- `pip install python-multipart`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf42ad9308323800c3a1470d5c943