### PR TITLE
Add puzzle extraction before background removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ frontend/node_modules/
 frontend/.next/
 # Vercel configuration
 .vercel/
+feedback.jsonl

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ perform one step of the workflow:
 The included Next.js site provides buttons that call these endpoints
 individually so you can inspect the output of every stage.
 
+### Button Workflow
+
+1. **Extract & Clean** – isolates each puzzle piece with a blur and
+   morphology step.
+2. **Remove Background** – applies GrabCut to a single piece.
+3. **Detect Corners** – highlights the four main corners on the piece.
+4. **Classify Piece** – labels the piece as corner, edge or middle.
+5. **Edge Descriptors** – computes color and shape metrics for each edge.
+6. **Batch Remove Background** – runs background removal on all uploaded images.
+7. **Segment Pieces** – splits a full image containing many pieces.
+8. **Manual Adjust** – overlays a color mask using custom threshold settings.
+
 ## Feature Extraction Pipeline
 
 Each puzzle edge is analyzed to produce several descriptors:

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -104,6 +104,21 @@ export default function Home() {
     }
   };
 
+  const runExtractThenRemove = async () => {
+    setLoading(true);
+    try {
+      const data = await postImage('extract_then_remove', file, {
+        blur: blurValue,
+        kernel_size: kernelSize,
+      });
+      if (data && data.pieces) {
+        setResult((r) => ({ ...r, extract_then_remove: data.pieces }));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const runBatchRemoveBackground = async () => {
     setLoading(true);
     try {
@@ -438,7 +453,7 @@ export default function Home() {
               }}
               style={{
                 position: 'absolute',
-                width: '100px',
+                width: '150px',
                 cursor: 'move',
               }}
             />
@@ -494,6 +509,7 @@ export default function Home() {
       </div>
 
       <div className="buttons" style={{ marginTop: '1rem' }}>
+        <button onClick={runExtractThenRemove} disabled={loading}>Extract &amp; Clean</button>
         <button onClick={runRemoveBackground} disabled={loading}>Remove Background</button>
         <button onClick={runDetectCorners} disabled={loading}>Detect Corners</button>
         <button onClick={runClassifyPiece} disabled={loading}>Classify Piece</button>
@@ -602,6 +618,29 @@ export default function Home() {
         </div>
       )}
 
+      {result.extract_then_remove && result.extract_then_remove.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Extracted Pieces</h3>
+          <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+            {result.extract_then_remove.map((p, idx) => (
+              <img
+                key={idx}
+                src={`data:image/png;base64,${p.image}`}
+                alt={`ex-${idx}`}
+                style={{
+                  width: '150px',
+                  height: '150px',
+                  objectFit: 'contain',
+                  marginRight: '0.5rem',
+                  marginBottom: '0.5rem',
+                  border: '1px solid #ccc',
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
       {result.corners && (
         <div style={{ marginTop: '1rem' }}>
           <h3>Corners</h3>
@@ -659,7 +698,7 @@ export default function Home() {
           <div
             style={{
               display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, 120px)',
+              gridTemplateColumns: 'repeat(auto-fill, 170px)',
               gap: '0.5rem',
             }}
           >
@@ -668,7 +707,7 @@ export default function Home() {
                 <img
                   src={`data:image/png;base64,${p}`}
                   alt={`piece-${idx}`}
-                  style={{ width: '100px', height: '100px', objectFit: 'contain' }}
+                  style={{ width: '150px', height: '150px', objectFit: 'contain' }}
                 />
                 <div>
                   <input
@@ -751,8 +790,8 @@ export default function Home() {
                       src={piece}
                       alt={`piece-${pidx}`}
                       style={{
-                        width: '100px',
-                        height: '100px',
+                        width: '150px',
+                        height: '150px',
                         objectFit: 'contain',
                         marginRight: '0.5rem',
                         marginBottom: '0.5rem',
@@ -767,8 +806,8 @@ export default function Home() {
                       src={piece}
                       alt={`contour-${pidx}`}
                       style={{
-                        width: '100px',
-                        height: '100px',
+                        width: '150px',
+                        height: '150px',
                         objectFit: 'contain',
                         marginRight: '0.5rem',
                         marginBottom: '0.5rem',


### PR DESCRIPTION
## Summary
- implement `extract_clean_pieces` helper
- add `/extract_then_remove` API route
- provide UI button for Extract & Clean
- enlarge piece thumbnails in the frontend
- document button workflow in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de836b61c8323928f3e2db321470c