### PR TITLE
Add user feedback for puzzle operations

### DIFF
--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -67,3 +67,8 @@ img {
   font-size: 0.8rem;
   color: #555;
 }
+
+.status {
+  margin-top: 1rem;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- show a textual status indicator in the Next.js interface
- update various puzzle actions to set progress messages
- style the status text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684dfac673dc8323b825d83799b84c5c