### PR TITLE
Add watershed segmentation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ The dataclasses `EdgeFeatures` and `PieceFeatures` store these metrics for each
 piece. `extract_edge_descriptors` returns dictionaries containing the vectors for
 all four edges in order.
 
+## Watershed Segmentation Demo
+
+The repository also offers a helper based on the watershed algorithm as
+outlined in [PyImageSearch's tutorial](https://pyimagesearch.com/2015/11/02/watershed-opencv/).
+The `watershed_steps` function exposes each stage of the process so the
+intermediate results can be inspected. Example usage:
+
+```python
+import cv2
+from puzzle.watershed import watershed_steps
+
+image = cv2.imread("pieces.jpg")
+outputs = watershed_steps(image)
+
+for name, step in outputs.items():
+    cv2.imshow(name, step)
+    cv2.waitKey(0)
+```
+
+The returned dictionary contains the grayscale conversion, binary mask, cleaned
+mask, sure background, sure foreground, unknown region, marker labels and the
+final watershed result with boundaries highlighted in red.
+
 ## Piece Compatibility Scoring
 
 The `puzzle.scoring` module implements helpers to compare edges and rank

--- a/puzzle/__init__.py
+++ b/puzzle/__init__.py
@@ -12,6 +12,7 @@ from .segmentation import (
     extract_mask_contours,
     PuzzlePiece,
 )
+from .watershed import watershed_steps
 from .features import (
     extract_edge_descriptors,
     classify_edge_types,
@@ -40,6 +41,7 @@ __all__ = [
     "segment_pieces_metadata",
     "extract_mask_contours",
     "PuzzlePiece",
+    "watershed_steps",
     "extract_edge_descriptors",
     "classify_edge_types",
     "EdgeFeatures",

--- a/puzzle/watershed.py
+++ b/puzzle/watershed.py
@@ -1,0 +1,56 @@
+import cv2
+import numpy as np
+
+
+def watershed_steps(image, kernel_size: int = 3, dist_thresh: float = 0.7):
+    """Perform watershed segmentation and return intermediate images.
+
+    Parameters
+    ----------
+    image : ndarray
+        BGR input image.
+    kernel_size : int, optional
+        Size of the morphological kernel used for opening/dilation.
+    dist_thresh : float, optional
+        Threshold for the distance transform relative to its max value.
+
+    Returns
+    -------
+    dict[str, ndarray]
+        Dictionary of intermediate images with keys:
+        ``gray``, ``thresh``, ``opening``, ``sure_bg``, ``sure_fg``,
+        ``unknown``, ``markers``, ``result``.
+    """
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    ret, thresh = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+
+    kernel = np.ones((kernel_size, kernel_size), np.uint8)
+    opening = cv2.morphologyEx(thresh, cv2.MORPH_OPEN, kernel, iterations=2)
+
+    sure_bg = cv2.dilate(opening, kernel, iterations=3)
+
+    dist = cv2.distanceTransform(opening, cv2.DIST_L2, 5)
+    ret, sure_fg = cv2.threshold(dist, dist_thresh * dist.max(), 255, 0)
+    sure_fg = sure_fg.astype(np.uint8)
+
+    unknown = cv2.subtract(sure_bg, sure_fg)
+
+    ret, markers = cv2.connectedComponents(sure_fg)
+    markers = markers + 1
+    markers[unknown == 255] = 0
+
+    markers = cv2.watershed(image.copy(), markers)
+    result = image.copy()
+    result[markers == -1] = [255, 0, 0]
+
+    return {
+        "gray": gray,
+        "thresh": thresh,
+        "opening": opening,
+        "sure_bg": sure_bg,
+        "sure_fg": sure_fg,
+        "unknown": unknown,
+        "markers": markers.astype(np.int32),
+        "result": result,
+    }

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -12,6 +12,7 @@ from puzzle.segmentation import (
     extract_mask_contours,
     PuzzlePiece,
 )
+from puzzle.watershed import watershed_steps
 
 
 def test_select_four_corners_returns_four():
@@ -178,3 +179,11 @@ def test_extract_mask_contours_filters_by_area():
     pieces, num = extract_mask_contours(mask)
     assert num == 3
     assert len(pieces) == 2
+
+
+def test_watershed_steps_returns_result():
+    img = np.full((30, 60, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (5, 5), (25, 25), (0, 0, 0), -1)
+    cv2.rectangle(img, (35, 5), (55, 25), (0, 0, 0), -1)
+    outputs = watershed_steps(img)
+    assert "result" in outputs and outputs["result"].shape == img.shape


### PR DESCRIPTION
## Summary
- implement `watershed_steps` helper exposing intermediate results
- export the new function from `puzzle.__init__`
- document usage in the README
- test watershed segmentation

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e03e60b488323a5d1f3c49aebf5f7