### PR TITLE
Improve frontend UX with spinner and preview

### DIFF
--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -72,3 +72,20 @@ img {
   margin-top: 1rem;
   font-style: italic;
 }
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin-left: 0.5rem;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- show preview of uploaded puzzle image
- display spinner next to action buttons while requests are in progress
- add CSS styles for spinner animation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684face96ee083239144818af5f81a3e